### PR TITLE
fix: "strict" option not being applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function generate(
   if (exact) res = "^" + res + "$";
   if (global) flags += "g";
   if (multiline) flags += "m";
-  return new RegExp(regex, flags);
+  return new RegExp(res, flags);
 }
 
 module.exports = generate();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflake-regex",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generates a regex to match Discord snowflakes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the generate function, the variable `regex` was being passed to the RegExp construtor rather than the `res` variable.

The introduced the unintended behavior of the `strict` flag not working, as `res` was an intermediary variable created to add `^$` to the beginning and end of the regex.